### PR TITLE
Fix hasOwnProperty

### DIFF
--- a/lib/arbcore.js
+++ b/lib/arbcore.js
@@ -258,14 +258,7 @@ arb.resourceMap_ = {};
  * @return {boolean} true if the object has not direct properties.
  * @private
  */
-arb.isEmpty = function(obj) {
-  for (var prop in obj) {
-    if (obj.hasOwnProperty(prop)) {
-      return false;
-    }
-  }
-  return true;
-};
+arb.isEmpty = obj => obj && typeof obj === "object" && Object.keys(obj).length === 0;
 
 
 /**
@@ -303,7 +296,7 @@ arb.register = function(namespaces, resource) {
  */
 arb.iterateRegistry = function(arbCallback) {
   for (var namespace in arb.resourceMap_) {
-    if (arb.resourceMap_.hasOwnProperty(namespace)) {
+    if (Object.prototype.hasOwnProperty.call(arb.resourceMap_, namespace)) {
       arbCallback(namespace);
     }
   }
@@ -367,7 +360,7 @@ arb.getResource = function(opt_selector) {
     }
   }
 
-  if (arb.resourceMap_.hasOwnProperty(bestNamespace)) {
+  if (Object.prototype.hasOwnProperty.call(arb.resourceMap_, bestNamespace)) {
     return arb.resourceMap_[bestNamespace];
   }
   return {};
@@ -381,7 +374,7 @@ arb.getResource = function(opt_selector) {
  */
 arb.isCompact = function(resource) {
   for (var prop in resource) {
-    if (resource.hasOwnProperty(prop) && prop[0] == '@') {
+    if (Object.prototype.hasOwnProperty.call(resource, prop) && prop[0] == '@') {
       return false;
     }
   }
@@ -410,8 +403,8 @@ arb.dbg.getType = function(resource, resId) {
     return 'attr';
   }
   var atResId = '@' + resId;
-  if (resource.hasOwnProperty(atResId) &&
-      resource[atResId].hasOwnProperty('type')) {
+  if (Object.prototype.hasOwnProperty.call(resource, atResId) &&
+      Object.prototype.hasOwnProperty.call(resource[atResId], 'type')) {
     return resource[atResId]['type'];
   }
   return '';
@@ -432,10 +425,10 @@ arb.dbg.getType = function(resource, resId) {
 arb.dbg.isInContext = function(resource, resId, context) {
   var contextRegex = new RegExp('^' + context + '($|:.*)');
   var atResId = '@' + resId;
-  return resId.charAt(0) != '@' &&
-      (!resource.hasOwnProperty(atResId) ||
-       !resource[atResId].hasOwnProperty('context') ||
-       contextRegex.test(resource[atResId]['context']));
+  return resId.charAt(0) !== '@' &&
+  (!Object.prototype.hasOwnProperty.call(resource, atResId) ||
+   !Object.prototype.hasOwnProperty.call(resource[atResId] || {}, 'context') ||
+   contextRegex.test(resource[atResId]?.context || ''));
 };
 
 
@@ -451,11 +444,10 @@ arb.dbg.isInContext = function(resource, resId, context) {
  */
 arb.dbg.getAttr = function(resource, resId, attrName) {
   var atResId = '@' + resId;
-  if (!resource.hasOwnProperty(atResId)) {
+  if (!Object.prototype.hasOwnProperty.call(resource, atResId)) {
     return '';
   }
 
   var msgAttr = resource[atResId];
-  return msgAttr.hasOwnProperty(attrName) ? msgAttr[attrName] : '';
+  return Object.prototype.hasOwnProperty.call(msgAttr, attrName) ? msgAttr[attrName] : '';
 };
-

--- a/test/arbcore_test.js
+++ b/test/arbcore_test.js
@@ -180,7 +180,7 @@ describe('arbcore', function() {
     it('match prefix context', function() {
       expect(arb.dbg.isInContext(resource, '#res1', 'main')).toBeTruthy();
     });
-    it('match default globalo context', function() {
+    it('match default global context', function() {
       expect(arb.dbg.isInContext(resource, 'res2', 'main:level2')).toBeTruthy();
     });
   });


### PR DESCRIPTION
This fixes `hasOwnProperty` usage to avoid potential issues with objects that might not inherit from `Object.prototype`.

# What’s changed?
- Replaced `obj.hasOwnProperty(prop)` with `Object.prototype.hasOwnProperty.call(obj, prop)`.
- Fixed checks on `resource[atResId]` to prevent errors when the object is `undefined` or `null`.

# Why does this matter?
- Prevents unexpected bugs when dealing with objects that don’t have hasOwnProperty.
- Makes the code more robust and reliable.